### PR TITLE
Use artifact relativePath, not filename

### DIFF
--- a/src/main/java/com/tikal/hudson/plugins/notification/model/BuildState.java
+++ b/src/main/java/com/tikal/hudson/plugins/notification/model/BuildState.java
@@ -271,7 +271,7 @@ public class BuildState {
 
         for ( Run.Artifact a : buildArtifacts ) {
             String artifactUrl = Jenkins.getInstance().getRootUrl() + run.getUrl() + "artifact/" + a.getHref();
-            updateArtifact( a.getFileName(), "archive", artifactUrl );
+            updateArtifact( a.relativePath, "archive", artifactUrl );
         }
     }
 


### PR DESCRIPTION
This allows multiple files of the same name in different
folders as the array keys no longer collide.
